### PR TITLE
Send JWT token via secure cookie

### DIFF
--- a/VemboAPI/Controllers/AuthController.cs
+++ b/VemboAPI/Controllers/AuthController.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using VemboAPI.Domain.DTOs;
 using VemboAPI.Domain.Entities;
 using VemboAPI.Infrastructure.Data;
 using VemboAPI.Infrastructure.Interfaces;
-
 
 namespace VemboAPI.Controllers
 {
@@ -13,11 +14,13 @@ namespace VemboAPI.Controllers
     {
         private readonly VemboDbContext _context;
         private readonly IJwtTokenGenerator _jwtTokenGenerator;
+        private readonly IConfiguration _configuration;
 
-        public AuthController(VemboDbContext context, IJwtTokenGenerator jwtTokenGenerator)
+        public AuthController(VemboDbContext context, IJwtTokenGenerator jwtTokenGenerator, IConfiguration configuration)
         {
             _context = context;
             _jwtTokenGenerator = jwtTokenGenerator;
+            _configuration = configuration;
         }
 
         [HttpPost("login")]
@@ -28,6 +31,16 @@ namespace VemboAPI.Controllers
                 return Unauthorized("Invalid credentials");
 
             var token = _jwtTokenGenerator.GenerateToken(user);
+            var jwtSettings = _configuration.GetSection("Jwt");
+
+            Response.Cookies.Append("token", token, new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Expires = DateTime.UtcNow.AddMinutes(double.Parse(jwtSettings["ExpireMinutes"]))
+            });
+
             return Ok(new { token });
         }
 
@@ -48,14 +61,25 @@ namespace VemboAPI.Controllers
                 XP = 0,
                 Rating = 0,
                 Level = 1,
-                Role = "User"
+                Role = "User",
             };
 
             _context.Users.Add(newUser);
             _context.SaveChanges();
 
             var token = _jwtTokenGenerator.GenerateToken(newUser);
+            var jwtSettings = _configuration.GetSection("Jwt");
+
+            Response.Cookies.Append("token", token, new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Expires = DateTime.UtcNow.AddMinutes(double.Parse(jwtSettings["ExpireMinutes"]))
+            });
+
             return Ok(new { token });
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- deliver JWTs via secure HttpOnly cookies on login and registration
- inject configuration to access token settings

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication tokens are now also set as secure, HTTP-only cookies upon login and registration, improving security and convenience for users.

* **Bug Fixes**
  * Cookie expiration is now dynamically configured based on application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->