### PR TITLE
Add admin panel menu endpoint and user moderation APIs

### DIFF
--- a/VemboAPI.Domain/DTO/AdminMenuDto.cs
+++ b/VemboAPI.Domain/DTO/AdminMenuDto.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace VemboAPI.Domain.DTOs
+{
+    public class AdminMenuDto
+    {
+        public IReadOnlyList<AdminMenuSectionDto> Sections { get; set; } = Array.Empty<AdminMenuSectionDto>();
+    }
+
+    public class AdminMenuSectionDto
+    {
+        public string Title { get; set; } = string.Empty;
+        public string? Icon { get; set; }
+        public IReadOnlyList<AdminMenuItemDto> Items { get; set; } = Array.Empty<AdminMenuItemDto>();
+    }
+
+    public class AdminMenuItemDto
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string HttpMethod { get; set; } = string.Empty;
+        public string Endpoint { get; set; } = string.Empty;
+        public IReadOnlyList<string> RelatedEntities { get; set; } = Array.Empty<string>();
+        public IReadOnlyList<string> AllowedRoles { get; set; } = Array.Empty<string>();
+    }
+}

--- a/VemboAPI.Domain/DTO/BlockUserDto.cs
+++ b/VemboAPI.Domain/DTO/BlockUserDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace VemboAPI.Domain.DTOs
+{
+    public class BlockUserDto
+    {
+        public DateTimeOffset? LockedUntil { get; set; }
+        public string? Reason { get; set; }
+    }
+}

--- a/VemboAPI.Domain/DTO/UserDto.cs
+++ b/VemboAPI.Domain/DTO/UserDto.cs
@@ -14,5 +14,7 @@
         public long XP { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+        public bool IsBlocked { get; set; }
+        public DateTimeOffset? LockedUntil { get; set; }
     }
 }

--- a/VemboAPI.Infrastructure/Interfaces/IAdminPanelService.cs
+++ b/VemboAPI.Infrastructure/Interfaces/IAdminPanelService.cs
@@ -1,0 +1,9 @@
+using VemboAPI.Domain.DTOs;
+
+namespace VemboAPI.Infrastructure.Interfaces
+{
+    public interface IAdminPanelService
+    {
+        AdminMenuDto BuildMenu();
+    }
+}

--- a/VemboAPI.Infrastructure/Interfaces/IUserService.cs
+++ b/VemboAPI.Infrastructure/Interfaces/IUserService.cs
@@ -1,3 +1,4 @@
+using System;
 using VemboAPI.Domain.DTOs;
 
 namespace VemboAPI.Infrastructure.Interfaces
@@ -7,6 +8,8 @@ namespace VemboAPI.Infrastructure.Interfaces
         Task CreateUser(CreateUserDto dto);
         Task UpdateUser(string id, UpdateUserDto dto);
         Task UpdateRoleAsync(string userId, string newRole);
+        Task BlockUserAsync(string userId, DateTimeOffset? lockedUntil, string? reason = null);
+        Task UnblockUserAsync(string userId);
 
         Task DeleteUser(int id);
 

--- a/VemboAPI.Infrastructure/Mapper/MappingProfile.cs
+++ b/VemboAPI.Infrastructure/Mapper/MappingProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using System;
 
 using VemboAPI.Domain.DTOs;
 using VemboAPI.Domain.Entities;
@@ -10,7 +11,15 @@ namespace VemboAPI.Infrastructure
         public MappingProfile()
         {
             // Користувач
-            CreateMap<User, UserDto>().ReverseMap();
+            CreateMap<User, UserDto>()
+                .ForMember(dest => dest.IsBlocked,
+                    opt => opt.MapFrom(src => src.LockoutEnd.HasValue && src.LockoutEnd.Value.UtcDateTime > DateTime.UtcNow))
+                .ForMember(dest => dest.LockedUntil, opt => opt.MapFrom(src => src.LockoutEnd))
+                .ReverseMap()
+                .ForMember(dest => dest.LockoutEnd, opt => opt.MapFrom(src => src.LockedUntil))
+                .ForMember(dest => dest.LockoutEnabled,
+                    opt => opt.MapFrom(src => src.LockedUntil.HasValue || src.IsBlocked))
+                .ForMember(dest => dest.PasswordHash, opt => opt.Ignore());
             CreateMap<CreateUserDto, User>().ReverseMap();
             CreateMap<UpdateUserDto, User>().ReverseMap();
 

--- a/VemboAPI.Infrastructure/Services/AdminPanelService.cs
+++ b/VemboAPI.Infrastructure/Services/AdminPanelService.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using VemboAPI.Domain.DTOs;
+using VemboAPI.Infrastructure.Interfaces;
+
+namespace VemboAPI.Infrastructure.Services
+{
+    public class AdminPanelService : IAdminPanelService
+    {
+        public AdminMenuDto BuildMenu()
+        {
+            var sections = new List<AdminMenuSectionDto>
+            {
+                new AdminMenuSectionDto
+                {
+                    Title = "Контент",
+                    Icon = "content",
+                    Items = new List<AdminMenuItemDto>
+                    {
+                        new AdminMenuItemDto
+                        {
+                            Title = "Створити таску (Quest)",
+                            Description = "Розробка нової таски (Quest) для прогресу користувачів.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/quests",
+                            RelatedEntities = new []{"Quest", "QuestDefinition"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Створити вправу",
+                            Description = "Створення вправи (Exercise) з повним налаштуванням контенту та медіа.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Exercise",
+                            RelatedEntities = new []{"Exercise", "Lesson", "Unit"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Створити рівень",
+                            Description = "Додавання нового рівня до обраного юніта.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Level",
+                            RelatedEntities = new []{"Level", "Unit"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Створити урок",
+                            Description = "Додавання уроку в межах конкретного рівня.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Lesson",
+                            RelatedEntities = new []{"Lesson", "Level"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        }
+                    }
+                },
+                new AdminMenuSectionDto
+                {
+                    Title = "Питання та відповіді",
+                    Icon = "quiz",
+                    Items = new List<AdminMenuItemDto>
+                    {
+                        new AdminMenuItemDto
+                        {
+                            Title = "Створити питання",
+                            Description = "Формування питання для вправи з типом Single або Multi.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Question",
+                            RelatedEntities = new []{"Question", "Exercise"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Додати відповіді (Single)",
+                            Description = "Створює варіант відповіді з єдиною правильною позначкою (IsCorrect = true лише в одного).",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Answer",
+                            RelatedEntities = new []{"Answer", "Question"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Додати відповіді (Multi)",
+                            Description = "Додає варіанти відповіді типу Multi (кілька записів з IsCorrect = true).",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/Answer",
+                            RelatedEntities = new []{"Answer", "Question"},
+                            AllowedRoles = new []{"Admin", "ContentManager"}
+                        }
+                    }
+                },
+                new AdminMenuSectionDto
+                {
+                    Title = "Користувачі",
+                    Icon = "users",
+                    Items = new List<AdminMenuItemDto>
+                    {
+                        new AdminMenuItemDto
+                        {
+                            Title = "Заблокувати користувача",
+                            Description = "Блокує доступ користувача до платформи на визначений час.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/User/{id}/block",
+                            RelatedEntities = new []{"User"},
+                            AllowedRoles = new []{"Admin"}
+                        },
+                        new AdminMenuItemDto
+                        {
+                            Title = "Розблокувати користувача",
+                            Description = "Знімає блокування та повертає доступ користувача.",
+                            HttpMethod = "POST",
+                            Endpoint = "/api/User/{id}/unblock",
+                            RelatedEntities = new []{"User"},
+                            AllowedRoles = new []{"Admin"}
+                        }
+                    }
+                }
+            };
+
+            return new AdminMenuDto
+            {
+                Sections = sections
+            };
+        }
+    }
+}

--- a/VemboAPI.Infrastructure/Services/UserService.cs
+++ b/VemboAPI.Infrastructure/Services/UserService.cs
@@ -1,4 +1,5 @@
-﻿using VemboAPI.Infrastructure.Data;
+using System;
+using VemboAPI.Infrastructure.Data;
 using VemboAPI.Infrastructure.Interfaces;
 using VemboAPI.Domain.Entities;
 using VemboAPI.Domain.DTOs;
@@ -108,6 +109,34 @@ namespace VemboAPI.Infrastructure.Services
                 throw new KeyNotFoundException($"User with ID {userId} not found.");
 
             user.Role = newRole;
+            user.UpdatedAt = DateTime.UtcNow;
+
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public async Task BlockUserAsync(string userId, DateTimeOffset? lockedUntil, string? reason = null)
+        {
+            var user = await _dbContext.Users.FindAsync(userId);
+
+            if (user == null)
+                throw new KeyNotFoundException($"User with ID {userId} not found.");
+
+            user.LockoutEnabled = true;
+            user.LockoutEnd = lockedUntil ?? DateTimeOffset.MaxValue;
+            user.UpdatedAt = DateTime.UtcNow;
+
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public async Task UnblockUserAsync(string userId)
+        {
+            var user = await _dbContext.Users.FindAsync(userId);
+
+            if (user == null)
+                throw new KeyNotFoundException($"User with ID {userId} not found.");
+
+            user.LockoutEnd = null;
+            user.LockoutEnabled = false;
             user.UpdatedAt = DateTime.UtcNow;
 
             await _dbContext.SaveChangesAsync();

--- a/VemboAPI/Controllers/AdminPanelController.cs
+++ b/VemboAPI/Controllers/AdminPanelController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using VemboAPI.Infrastructure.Interfaces;
+
+namespace VemboAPI.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Roles = "Admin")]
+    public class AdminPanelController : ControllerBase
+    {
+        private readonly IAdminPanelService _adminPanelService;
+
+        public AdminPanelController(IAdminPanelService adminPanelService)
+        {
+            _adminPanelService = adminPanelService;
+        }
+
+        [HttpGet("menu")]
+        public IActionResult GetMenu()
+        {
+            var menu = _adminPanelService.BuildMenu();
+            return Ok(menu);
+        }
+    }
+}

--- a/VemboAPI/Controllers/UserController.cs
+++ b/VemboAPI/Controllers/UserController.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Data;
 using System.Security.Claims;
 using VemboAPI.Domain.DTOs;
@@ -136,6 +137,50 @@ public class UserController : Controller
 
         await _userService.UpdateRoleAsync(userId, newRole);
         return Ok($"Role updated to {newRole}.");
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpPost("{id}/block")]
+    public async Task<IActionResult> BlockUser(string id, [FromBody] BlockUserDto dto)
+    {
+        if (dto == null)
+            return BadRequest("Block data is required.");
+
+        try
+        {
+            var lockedUntil = dto.LockedUntil ?? DateTimeOffset.MaxValue;
+            await _userService.BlockUserAsync(id, lockedUntil, dto.Reason);
+
+            return Ok(new
+            {
+                Message = $"User {id} has been blocked.",
+                LockedUntil = lockedUntil,
+                Reason = dto.Reason
+            });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpPost("{id}/unblock")]
+    public async Task<IActionResult> UnblockUser(string id)
+    {
+        try
+        {
+            await _userService.UnblockUserAsync(id);
+
+            return Ok(new
+            {
+                Message = $"User {id} has been unblocked."
+            });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
     }
 
 }

--- a/VemboAPI/Program.cs
+++ b/VemboAPI/Program.cs
@@ -158,6 +158,7 @@ public class Program
         builder.Services.AddScoped<IAchievementService, AchievementService>();
         builder.Services.AddScoped<IBadgeService, BadgeService>();
         builder.Services.AddScoped<IUserStatisticService, UserStatisticService>();
+        builder.Services.AddScoped<IAdminPanelService, AdminPanelService>();
         builder.Services.AddScoped<IUserLeaderBoardService, UserLeaderBoardService>();
         builder.Services.AddScoped<IUserAchievementService, UserAchievementService>();
         builder.Services.AddScoped<IBadgeService, BadgeService>();


### PR DESCRIPTION
## Summary
- add DTOs, service, and controller that expose a structured admin menu for content management tasks
- extend user services and controller with block/unblock endpoints and expose lockout status in user DTOs
- register the admin panel service and update mappings to include lockout metadata

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*